### PR TITLE
moves flask app creation to a function

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,51 @@
+from urllib.parse import quote
+from flask import Flask
+from flask_migrate import Migrate
+import secrets
+from .database.db import db
+from flask_login import LoginManager, current_user, login_required, logout_user
+
+
+def create_app():
+    
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://postgres:password@localhost/subtunes'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SESSION_TYPE'] = 'filesystem' 
+
+    secret_key = secrets.token_hex(24)
+    app.config['SECRET_KEY'] = secret_key
+    
+    register_blueprints(app)
+    
+    register_extensions(app)
+    
+    return app
+
+def app_configs(app, configs):
+    pass
+
+
+def register_blueprints(app):
+    PREFIX = "/api"
+    
+    from .blueprints.spotify_auth_api import bp as spotify_auth_api
+    app.register_blueprint(spotify_auth_api)
+
+    from .blueprints.tunes_api import bp as tunes_api
+    app.register_blueprint(tunes_api)
+
+    from .blueprints.search import bp as search_api
+    app.register_blueprint(search_api, url_prefix=PREFIX)
+
+    from .blueprints.subtunes_api import bp as subtunes_api
+    app.register_blueprint(subtunes_api)
+
+
+def register_extensions(app):
+    db.init_app(app)
+    migrate = Migrate(app, db)
+
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+

--- a/api/index.py
+++ b/api/index.py
@@ -6,33 +6,10 @@ from .database.db import db
 from .model.user import User
 from flask_login import LoginManager, current_user, login_required, logout_user
 
-PREFIX = "/api"
+from . import create_app
 
-app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://postgres:password@localhost/subtunes'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['SESSION_TYPE'] = 'filesystem' 
+app = create_app()
 
-secret_key = secrets.token_hex(24)
-app.config['SECRET_KEY'] = secret_key
-
-db.init_app(app)
-migrate = Migrate(app, db)
-
-login_manager = LoginManager()
-login_manager.init_app(app)
-
-from .blueprints.spotify_auth_api import bp as spotify_auth_api
-app.register_blueprint(spotify_auth_api)
-
-from .blueprints.tunes_api import bp as tunes_api
-app.register_blueprint(tunes_api)
-
-from .blueprints.search import bp as search_api
-app.register_blueprint(search_api, url_prefix=PREFIX)
-
-from .blueprints.subtunes_api import bp as subtunes_api
-app.register_blueprint(subtunes_api)
 
 @app.route("/")
 def index():
@@ -54,11 +31,11 @@ def home():
     else:
         return "no user logged in."
 
-@login_manager.user_loader
+@app.login_manager.user_loader
 def load_user(user_id):
     return User.query.get(int(user_id))
 
-@login_manager.unauthorized_handler
+@app.login_manager.unauthorized_handler
 def unauthorized_callback():
     flash("You need to be logged in to access this page.", "error")
     return redirect(url_for('spotify_auth_api.login')) 


### PR DESCRIPTION
## Describe your changes
This PR moves the creation process of the flask app to the `api/__init__.py` file and into the `create_app` function. This is necessary in order to instantiate the flask backend multiple times and with different configs i.e. for unit testing, dev, prod etc

## Issue Ticket title and link
move flask app creation to function
https://www.notion.so/marcos-mdob/Move-flask-app-creation-to-function-89388fd9fa404b48afb43eed2d55e46d?pvs=4

## Test Steps

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have listed testing steps above


