### PR TITLE
Playlist endpoint fix, new top tunes endpoint, code cleanup

### DIFF
--- a/api/blueprints/search.py
+++ b/api/blueprints/search.py
@@ -1,53 +1,51 @@
 """" This module contains the blueprint for the tunes api endpoints. """
 
-from urllib.parse import quote
-from flask import Flask, request, redirect, session, url_for, Blueprint, jsonify, current_app
-from ..database.db import db
+import os
+import requests
+
+from ..blueprints.spotify_auth_api import get_auth_header
 from ..model.playlist import Playlist
 from ..model.subtune import Subtune
-from ..model.tune import Tune
-from ..spotify_api_endpoints import spotify_endpoints
-from ..blueprints.spotify_auth_api import get_auth_header
-import requests
-import os
 
+from flask import Blueprint, current_app, jsonify, request, session
 
 bp = Blueprint('search_api', __name__)
 
-#SPOTIFY_API_URL = spotify_endpoints['SPOTIFY_API_URL']
 SPOTIFY_API_URL = f"{os.environ.get('SPOTIFY_API_BASE_URL')}/{os.environ.get('SPOTIFY_API_VERSION')}"
 SPOTIFY_SEARCH_API_URL = f"{SPOTIFY_API_URL}/search"
-
-the_query="nadie&type=album&include_external=audio&locale=en-US%2Cen%3Bq%3D0.9%2Ces%3Bq%3D0.8&offset=0&limit=20"
 
 @bp.route("/search/next", methods=["GET"])
 def search_next():
     next_results = session.get('next', None)
     if next_results is None:
         return jsonify({'error': 'No more results'}), 404
+    
     query = next_results.split('?')[1]
-    current_app.logger.info("next query:" + query)
+
+    current_app.logger.debug("next query:" + query)
+
     resp = search_tune(query)
     data = resp[0].get_json()
-    current_app.logger.info(data)
+
+    current_app.logger.debug(data)
+
     if resp[0].status_code == 200:
         return jsonify(data), 200
     else:
         return jsonify({'error': 'Failed to fetch tracks from Spotify'}), resp[0].status_code
-    
 
 @bp.route("/search/tune", methods=["GET"])
-def search_tune(query = "name=nadie sabe lo que"):
+def search_tune(query = ""):
+
+    if request.args.get("query") is None or request.args.get("query") == "":
+        return jsonify({'error': 'search query required'}), 400
     # Get the search term from the query parameters
     query = "name={}".format(request.args.get('query'))
-    
-    current_app.logger.info(query)
-
-    if not query:
-        return jsonify({'error': 'Query parameter "query" is required'}), 400
-
-
     auth_header = get_auth_header(session['expire_time'])
+    
+    current_app.logger.debug(query)
+
+    # TODO: improve our search.
     params = {
         "q": query,
         "type": "album,artist,track",
@@ -59,20 +57,20 @@ def search_tune(query = "name=nadie sabe lo que"):
 
     response = requests.get(SPOTIFY_SEARCH_API_URL, headers=auth_header, params=params)
 
-    current_app.logger.info(response)
+    current_app.logger.debug(response)
     
-    hasNext = None
     if response.status_code == 200:
         # Parse the response and extract track information
         tracks = response.json().get('tracks', {}).get('items', [])
         next_results = response.json().get('tracks', {}).get('next', '')
         session['next'] = next_results
+
         if next_results is None:
             del session['next']
-        current_app.logger.info(tracks[0].keys())
+
+        current_app.logger.debug(tracks[0].keys())
         # Extract relevant information from each track
         track_info = [{'id': track['id'], 'name': track['name'], 'artist': track['artists'][0]['name'], 'external': track['preview_url'], 'cover': track['album']['images'][0]['url']} for track in tracks]
-
         return jsonify({'tracks': track_info, 'next': True if next_results else None}), 200
     else:
         return jsonify({'error': 'Failed to fetch tracks from Spotify'}), response.status_code
@@ -84,31 +82,29 @@ def search_subtune(query = ""):
     if not query:
         return jsonify({'error': 'Query parameter "query" is required'}), 400
     
-    current_app.logger.info("query={}".format(query))
+    current_app.logger.debug("query={}".format(query))
 
     with current_app.app_context():
         subtunes = Subtune.query.filter(Subtune.name.ilike(query)).all()
         
         # check if the subtune exists
         if subtunes is None:
-            return {"error": "subtune not found"}, 404
+            return {"error": "no subtunes like {}".format(query)}, 404
         
-        current_app.logger.info(subtunes)
+        current_app.logger.debug(subtunes)
 
-        resp = []
+        response = []
 
         for subtune in subtunes:
             subtune_obj = {"name": subtune.name, "description": subtune.description, "id": subtune.id}
             tunes = sorted(subtune.subtune_tunes, key=lambda subtune_tune: subtune_tune.order_in_subtune)
             subtune_obj["tunes"] = [subtune_tune.tune for subtune_tune in tunes]
             
-            resp.append({"subtune": subtune_obj})
+            response.append({"subtune": subtune_obj})
         
-        current_app.logger.info("\n\n\n")
-
-        current_app.logger.info(resp)
+        current_app.logger.debug(response)
         
-        return resp, 200
+        return response, 200
 
 @bp.route("/search/playlist", methods=["GET"])
 def search_playlist(query = ""):
@@ -124,21 +120,19 @@ def search_playlist(query = ""):
         
         # check if the playlist exists
         if playlists is None:
-            return {"error": "playlists not found"}, 404
+            return {"error": "no playlists like {}".format(query)}, 404
         
-        current_app.logger.info(playlists)
+        current_app.logger.debug(playlists)
 
-        resp = []
+        response = []
 
         for playlist in playlists:
             playlist_obj = {"name": playlist.name, "description": playlist.description, "id": playlist.id}
             tunes = sorted(playlist.playlist_tunes, key=lambda playlist_tune: playlist_tune.order_in_playlist)
             playlist_obj["tunes"] = [playlist_tune.tune for playlist_tune in tunes]
             
-            resp.append({"playlist": playlist_obj})
+            response.append({"playlist": playlist_obj})
         
-        current_app.logger.info("\n\n\nplaylist:")
-
-        current_app.logger.info(resp)
+        current_app.logger.debug(response)
         
-        return resp, 200
+        return response, 200

--- a/api/blueprints/subtunes_api.py
+++ b/api/blueprints/subtunes_api.py
@@ -7,7 +7,7 @@ from ..database.db import db
 from ..model.subtune import Subtune
 from ..model.subtune_tune import Subtune_Tune
 
-from flask import request, Blueprint, jsonify, current_app
+from flask import Blueprint, current_app, jsonify, request
 from flask_login import current_user, login_required
 
 bp = Blueprint('subtunes_api', __name__)
@@ -33,20 +33,20 @@ def get_image_url(img_path):
 #         return False, e
 
 # delete subtune image from aws s3 bucket
-def delete_file_from_s3(file_url):
+# def delete_file_from_s3(file_url):
 
-    # Initialize the S3 resource
-    s3 = boto3.resource('s3',
-                        aws_access_key_id=current_app.config["AWS_ACCESS_KEY_ID"],
-                        aws_secret_access_key=current_app.config["AWS_SECRET_ACCESS_KEY"])
+#     # Initialize the S3 resource
+#     s3 = boto3.resource('s3',
+#                         aws_access_key_id=current_app.config["AWS_ACCESS_KEY_ID"],
+#                         aws_secret_access_key=current_app.config["AWS_SECRET_ACCESS_KEY"])
 
-    # Delete the file from the S3 bucket
-    try:
-        s3.Object(bucket_name, file_key).delete()
-        return True  # Deletion successful
-    except Exception as e:
-        print(e)  # Handle or log the error
-        return False  # Deletion failed
+#     # Delete the file from the S3 bucket
+#     try:
+#         s3.Object(bucket_name, file_key).delete()
+#         return True  # Deletion successful
+#     except Exception as e:
+#         print(e)  # Handle or log the error
+#         return False  # Deletion failed
 
 # get subtune by id
 @bp.route("/subtune/<id>", methods=["GET"])

--- a/api/blueprints/tunes_api.py
+++ b/api/blueprints/tunes_api.py
@@ -1,51 +1,44 @@
 """" This module contains the blueprint for the tunes api endpoints. """
 
-import requests
 import os
-
-from ..database.db import db
-
-from ..model.tune import Tune
-from ..model.subtune_tune import Subtune_Tune
-
-from ..spotify_api_endpoints import spotify_endpoints
+import requests
 
 from ..blueprints.spotify_auth_api import get_auth_header
+from ..database.db import db
+from ..model.tune import Tune
+from ..model.subtune_tune import Subtune_Tune
+from ..spotify_api_endpoints import spotify_endpoints
 
-from flask import Flask, request, redirect, session, url_for, Blueprint, jsonify, current_app
-
+from flask import request, session, Blueprint, jsonify, current_app
 
 bp = Blueprint('tunes_api', __name__)
 
-
 SPOTIFY_API_URL = f"{os.environ.get('SPOTIFY_API_BASE_URL')}/{os.environ.get('SPOTIFY_API_VERSION')}"
 
-
-
 @bp.route("/tune/<id>", methods=["GET"])
-def get_tune(id = "-1"):
+def get_tune(id = None):
     """ 
         This endpoint gets a tune from the database if it exists, otherwise it
         gets the track from the Spotify API and saves it to the database before
         returning it.
     """
-    # in case of no id, return a random tune for testing
-    tune_id = "11dFghVXANMlKmJXsNCbNl" if id == "-1" else id
+    track_endpoint = f"{SPOTIFY_API_URL}/tracks/{id}"
+
+    if id is None:
+        return {"error": "no tune id given"}
     
-    tune = Tune.query.get(tune_id)
+    tune = Tune.query.get(id)
     if tune is not None:
         return {"tune": tune}, 200
     
     expire_time = session['expire_time'] if 'expire_time' in session else -1
     auth_header = get_auth_header(expire_time) 
-
-    track_endpoint = f"{SPOTIFY_API_URL}/tracks/{tune_id}"
-    tune_data_response = requests.get(track_endpoint, headers=auth_header)
+    response = requests.get(track_endpoint, headers=auth_header)
     
-    if tune_data_response.status_code != 200:
-        return {"error": f"error getting track with {tune_id} from Spotify", "HTTPResponse Code": tune_data_response.status_code}, tune_data_response.status_code
+    if response.status_code != 200:
+        return {"error": f"error getting track with {id} from Spotify", "HTTPResponse Code": response.status_code}, response.status_code
 
-    tune_data = tune_data_response.json()
+    tune_data = response.json()
     
     # create a Tune object from the response   
     tune = Tune(
@@ -68,16 +61,49 @@ def get_tune(id = "-1"):
 
 #delete tune from db
 @bp.route("/tune/<id>", methods=["DELETE"])
-def delete_tune(id="-1"):
+def delete_tune(id=None):
     with current_app.app_context():
+        if id is None or id == "":
+            return {"error": "tune id required"}, 404
+
         tune = Tune.query.get(id)
         if tune is None:
             return {"error": "tune not found"}, 404
         
         subtunes = Subtune_Tune.query.filter_by(tune_id=id).all()
+        
         if len(subtunes) > 0:
             return {"error": f"Tune was not removed. Tune {tune.name} is currently in {len(subtunes)} subtunes."}, 400
         
         db.session.delete(tune)
         db.session.commit()
         return {"error": "tune deleted"}, 200
+    
+
+@bp.route("/tune/top", methods=["GET"])
+def get_top_tunes(id="-1"):
+    with current_app.app_context():
+        user_id = int(request.cookies.get('spotify_id'))
+
+        if user_id is None:
+            return jsonify({"error": "user_id is required"}), 400
+        
+        top_tracks_url = f"{SPOTIFY_API_URL}/me/top/tracks"
+
+        expire_time = session['expire_time'] if 'expire_time' in session else -1
+        auth_header = get_auth_header(expire_time) 
+        headers = {'Authorization': f'Bearer {auth_header}'}
+
+        response = requests.get(top_tracks_url, headers=headers)
+    
+        if response.status_code != 200:
+            return {"error": response.text}
+
+        tracks = response.json().get('items', [])
+        next_results = response.json().get('next', '')
+        if next_results is not None:
+            session['next'] = next_results
+
+        track_info = [{'id': track['id'], 'name': track['name'], 'artist': track['artists'][0]['name'], 'external': track['preview_url'], 'cover': track['album']['images'][0]['url']} for track in tracks]
+
+        return jsonify({'tracks': track_info, 'next': True if next_results else None}), 200

--- a/app/boilerplate/createsubtune/page.tsx
+++ b/app/boilerplate/createsubtune/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ChangeEvent, useState }  from 'react';
+import { ChangeEvent, useState , useEffect}  from 'react';
 import useSWR from 'swr';
 import Navigation from '../components/Navigation';
 import SearchBar from '../components/SearchBar';
@@ -40,6 +40,31 @@ const SubtuneCreator = () => {
       console.error('Error fetching search results:', error);
     }
   };
+
+   
+  useEffect(() => {
+    const fetchTopTunes = async () => {
+      try {
+        const response = await fetch('/api/tune/top', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include', // Ensure cookies are sent with the request
+        });
+        if (!response.ok) {
+          throw new Error(`Error fetching tunes: ${response.statusText}`);
+        }
+        const data = await response.json();
+        setSearchResults(data['tracks']);
+        console.log(data);
+      } catch (error) {
+        console.error('Error fetching top tunes:', error);
+      }
+    };
+
+    fetchTopTunes();
+  }, []);
 
   const handleAddTune = (tune : tune) => {
     // Add the selected song to the playlist

--- a/app/boilerplate/home/page.tsx
+++ b/app/boilerplate/home/page.tsx
@@ -43,13 +43,23 @@ const Home = ({searchParams}) => {
   useEffect(() => {
     const fetchPlaylists = async () => {
       try {
-        const response = await fetch('/api/user/1/playlists');
+        const response = await fetch('/api/user/playlists', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include', // Ensure cookies are sent with the request
+        });
+        if (!response.ok) {
+          throw new Error(`Error fetching playlists: ${response.statusText}`);
+        }
         const data = await response.json();
         setPlaylists(data);
       } catch (error) {
-        console.error('Error fetching playlist:', error);
+        console.error('Error fetching playlists:', error);
       }
     };
+    
 
     fetchPlaylists();
   }, []);

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,6 @@ export function middleware(request: NextRequest) {
   } else {
     // Token does not exist, redirect to Spotify login
     console.log("no spotify token found, redirecting")
-
     const redirectUrl = new URL('/api/login', request.url);
     return NextResponse.redirect(redirectUrl);
   }


### PR DESCRIPTION
## Describe your changes
- Fixes playlist endpoints to not have hardcoded user id in path (similar to other PR)
- Adds an endpoint used for retrieving a users top tunes. Useful for filling out search bar with content before the user searches. TODO: improve algorithm behind deciding what songs to pick

- Code cleanup. consistency across variables, ordering of imports, etc.


Assumption will be in the future we will on load do this call. maybe if the search bar is empty it will always default to this search or only on first load.

## Issue Ticket title and link

## Test Steps
1. run locally.
2. log in to spotify
3. go to http://127.0.0.1:3000/boilerplate/createsubtune
4. open console and see logs for an Object. the object should have top 20 tunes for you. Also info on pagination is included so we can implement that as well.
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have listed testing steps above

